### PR TITLE
Fix loaded ceol not always playing at correct BPM. Fixes #9

### DIFF
--- a/src/controlclass.as
+++ b/src/controlclass.as
@@ -1178,6 +1178,8 @@
 			changemusicbox(0);
 			looptime = 0;
 			
+			_driver.play(null, false);
+
 			fixmouseclicks = true;
 			showmessage("SONG LOADED");
 		}
@@ -1203,6 +1205,8 @@
 			changemusicbox(0);
 			looptime = 0;
 			
+			_driver.play(null, false);
+
 			fixmouseclicks = true;
 			showmessage("SONG LOADED");
 		}


### PR DESCRIPTION
Calling `SiONDriver#play` again after loading a `.ceol` seems to fix this issue and has no other side effects. I have tested this on Mac OSX.