### PR TITLE
set instrument to grand piano when clicking new song

### DIFF
--- a/src/control.as
+++ b/src/control.as
@@ -956,6 +956,10 @@
 			numinstrument = 1;
 			instrumentmanagerview = 0;
 			patternmanagerview = 0;
+			// set instrument to grand piano
+			instrument[0] = new instrumentclass();
+			instrument[0].voice = _presets["midi.piano1"];
+			instrument[0].updatefilter();
 			showmessage("NEW SONG CREATED");
 		}
 		


### PR DESCRIPTION
There's some weird behavior if `instrument[0]` is a drumkit and you click the New Song button.

Video: http://monosnap.com/file/zXRHnd68BiP0s80IUF16bZYtCCrIqD

The color scheme is set as if you've selected the midi grand piano, but you've still got a drumkit activated, and you're scrolled way above where you should be. And if you place notes up there and scroll down, then you can't scroll back up to erase those notes.

This is confusing behavior, so how about setting `instrument[0]` to the default midi grand piano when you call `newsong()`?