### PR TITLE
Add test for swf-js communication in web build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,16 @@ os: Windows Server 2012
 
 # Install scripts. (runs after repo cloning)
 install:
+  # download and install adobe flash activex plugin (for ie)
+  - ps: Start-FileDownload 'http://download.macromedia.com/get/flashplayer/current/licensing/win/install_flash_player_17_active_x.msi'
+  - ps: msiexec /i install_flash_player_17_active_x.msi /quiet /qn /norestart
   # download and unzip adobe air sdk
   - ps: Start-FileDownload 'http://airdownload.adobe.com/air/win/download/17.0/AIRSDK_Compiler.zip'
   - ps: '& "C:\Program Files\7-Zip\7z.exe" x AIRSDK_Compiler.zip "-o.\AIRSDK_Compiler"'
+  # test dependencies
+  - ruby --version
+  - gem install sinatra --version 1.4.6 --no-rdoc --no-ri
+  - gem install watir-webdriver --version 0.7.0 --no-rdoc --no-ri
 
 
 #---------------------------------#
@@ -18,9 +25,9 @@ install:
 
 build_script:
   # build desktop version
-  - AIRSDK_Compiler\bin\amxmlc -swf-version 20 -default-frame-rate 60 -default-size 768 480 -library-path+=lib/sion065.swc -source-path+=src -default-background-color 0x000000 -warnings -strict src/Main.as -o BoscaCeoil.swf -define+=CONFIG::desktop,true -define+=CONFIG::web,false
+  - AIRSDK_Compiler\bin\amxmlc -swf-version 28 -default-frame-rate 60 -default-size 768 560 -library-path+=lib/sion065.swc -source-path+=src -default-background-color 0x000000 -warnings -strict src/Main.as -o BoscaCeoil.swf -define+=CONFIG::desktop,true -define+=CONFIG::web,false
   # build web version
-  - AIRSDK_Compiler\bin\amxmlc -swf-version 20 -default-frame-rate 60 -default-size 768 480 -library-path+=lib/sion065.swc -source-path+=src -default-background-color 0x000000 -warnings -strict src/Main.as -o BoscaCeoil.swf -define+=CONFIG::desktop,false -define+=CONFIG::web,true
+  - AIRSDK_Compiler\bin\amxmlc -swf-version 28 -default-frame-rate 60 -default-size 768 560 -library-path+=lib/sion065.swc -source-path+=src -default-background-color 0x000000 -warnings -strict src/Main.as -o BoscaCeoil.swf -define+=CONFIG::desktop,false -define+=CONFIG::web,true
 
 
 #---------------------------------#
@@ -29,7 +36,4 @@ build_script:
 
 # Post-install test scripts.
 test_script:
-  # - #todo
-
-# Disable automatic tests.
-test: off
+  - ruby test/test-web.rb

--- a/test/test-web.html
+++ b/test/test-web.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+  </head>
+  <body>
+    <div id="container">
+      <div id="bosca-container">
+        <object id="BoscaCeoil" type="application/x-shockwave-flash" data="../BoscaCeoil.swf" width="100%" height="100%" allowscriptaccess="always" allowfullscreen="true">
+          <param name="scale" value="default">
+          <h1>This website requires Flash.</h1>
+        </object>
+      </div>
+
+      <div id="js-enabled">
+        <!-- "js enabled" goes here -->
+      </div>
+
+      <div id="result">
+        <!-- "success" goes here -->
+      </div>
+    </div>
+
+    <script type="text/javascript">
+      // mock ExternalInterface functions
+      window.Bosca = {
+        _isReady: function () {
+          document.getElementById("result").textContent = "success";
+          return true;
+        },
+        _getStartupCeol: function () {
+          return '';
+        }
+      };
+
+      document.getElementById("js-enabled").textContent = "js enabled";
+    </script>
+  </body>
+</html>

--- a/test/test-web.rb
+++ b/test/test-web.rb
@@ -1,0 +1,69 @@
+require 'watir-webdriver'
+require 'sinatra/base'
+require 'thread'
+
+
+#   If the web build of BoscaCeoil.swf works correctly, then it
+# should call the window.Bosca._isReady() javascript function.
+# In our mock test-web.html file, that function will insert a
+# success message in the webpage.
+#
+#   This script runs a webserver, opens test-web.html in a web
+# browser, and checks for the success message.
+
+
+class TestApp < Sinatra::Base
+  set :public_folder, File.join(File.dirname(__FILE__), '..')
+end
+
+
+# http://stackoverflow.com/a/16543644/1924875
+def sinatra_run_wait(app, opts)
+  queue = Queue.new
+  thread = Thread.new do
+    Thread.abort_on_exception = true
+    app.run!(opts) do |server|
+      queue.push("started")
+    end
+  end
+  queue.pop # blocks until the run! callback runs
+end
+
+
+sinatra_run_wait(TestApp, :port => 3000, :server => 'webrick')
+sleep 1
+
+test_url = "http://localhost:3000/test/test-web.html"
+
+client = Selenium::WebDriver::Remote::Http::Default.new
+client.timeout = 180 # seconds - default is 60
+
+#   I had mega problems getting firefox/chrome driver to work properly on
+# Appveyor, so I'm using IE here instead.
+browser = :ie
+
+if browser == :ie
+  ie_caps = Selenium::WebDriver::Remote::Capabilities.ie("initialBrowserUrl" => test_url)
+  ie_driver = Selenium::WebDriver.for :ie, :desired_capabilities => ie_caps, :http_client => client
+  b = Watir::Browser.new ie_driver
+else
+  b = Watir::Browser.new browser, :http_client => client
+  b.goto test_url
+end
+
+at_exit {
+  b.close
+}
+
+# The actual test
+begin
+  b.div(:id => "result").wait_until_present(30)
+  Watir::Wait.until(60, 'js-enabled') { b.text.include? 'js enabled' }
+  Watir::Wait.until(60, 'swf-js') { b.text.include? 'success' }
+rescue => e
+  puts e
+  exit 1
+end
+
+
+exit 0


### PR DESCRIPTION
Even if the web version of BoscaCeoil.swf can be successfully compiled, it does not necessarily mean it will work in a browser's flash player.

This automated test checks to see if the swf can be loaded in a web browser and communicate with the Javascript on a web page.