### PR TITLE
Fix pattern editor letting you write out of bounds notes

### DIFF
--- a/src/gfx.as
+++ b/src/gfx.as
@@ -175,12 +175,18 @@
 			
 			//Background alternating colour rows
 			for (i = 0; i < notesonscreen; i++){
-				if (i % 2 == 0) {
-					fillrect(0, screenheight - linesize - (i * linesize), screenwidth, linesize, 100 + (control.musicbox[control.currentbox].palette * 10));
-					fillrect(0, screenheight - linesize - (i * linesize), screenwidth, 2, 103+(control.musicbox[control.currentbox].palette*10));
-				}else{
-					fillrect(0, screenheight - linesize - (i * linesize), screenwidth, linesize, 101 + (control.musicbox[control.currentbox].palette * 10));
-					fillrect(0, screenheight - linesize - (i * linesize), screenwidth, 2, 103+(control.musicbox[control.currentbox].palette*10));
+				var instsize:int = control.pianorollsize;
+				if (control.instrument[control.musicbox[control.currentbox].instr].type >= 1) {
+					instsize = control.drumkit[control.instrument[control.musicbox[control.currentbox].instr].type - 1].size;
+				}
+				if (control.musicbox[control.currentbox].start + i - 1 < instsize) {
+					if (i % 2 == 0) {
+						fillrect(0, screenheight - linesize - (i * linesize), screenwidth, linesize, 100 + (control.musicbox[control.currentbox].palette * 10));
+						fillrect(0, screenheight - linesize - (i * linesize), screenwidth, 2, 103+(control.musicbox[control.currentbox].palette*10));
+					}else{
+						fillrect(0, screenheight - linesize - (i * linesize), screenwidth, linesize, 101 + (control.musicbox[control.currentbox].palette * 10));
+						fillrect(0, screenheight - linesize - (i * linesize), screenwidth, 2, 103+(control.musicbox[control.currentbox].palette*10));
+					}
 				}
 			}
 			

--- a/src/includes/input.as
+++ b/src/includes/input.as
@@ -138,7 +138,8 @@
 					control.musicbox[control.currentbox].recordfilter = 1 - control.musicbox[control.currentbox].recordfilter;
 				}
 			}else {
-				if(control.musicbox[control.currentbox].start + control.cursory - 1 > -1){
+				if(control.musicbox[control.currentbox].start + control.cursory - 1 > -1 &&
+					 control.musicbox[control.currentbox].start + control.cursory - 1 < control.pianorollsize) {
 					control.currentnote = control.pianoroll[control.musicbox[control.currentbox].start + control.cursory - 1];
 					if (control.musicbox[control.currentbox].noteat(control.cursorx, control.currentnote)) {
 						control.musicbox[control.currentbox].removenote(control.cursorx, control.currentnote);


### PR DESCRIPTION
E.g. if you were in a chord or changed from another panel, the pattern editor would sometimes show you notes above 104, and you could write those, but it would do the wrong thing nearly always.

This bug was really annoying since they weren't rendered, and you couldn't always scroll erase them, or at least it wasn't obvious how.
