### PR TITLE
fixed out of bounds access on record filter save

### DIFF
--- a/src/control.as
+++ b/src/control.as
@@ -1338,7 +1338,7 @@
 				filestring += String(musicbox[i].recordfilter) + ",";
 				if (musicbox[i].recordfilter == 1)
 				{
-					for (j = 0; j < 32; j++)
+					for (j = 0; j < 16; j++)
 					{
 						filestring += String(musicbox[i].volumegraph[j]) + ",";
 						filestring += String(musicbox[i].cutoffgraph[j]) + ",";
@@ -1447,7 +1447,7 @@
 					musicbox[i].recordfilter = readfilestream();
 					if (musicbox[i].recordfilter == 1)
 					{
-						for (j = 0; j < 32; j++)
+						for (j = 0; j < 16; j++)
 						{
 							musicbox[i].volumegraph[j] = readfilestream();
 							musicbox[i].cutoffgraph[j] = readfilestream();


### PR DESCRIPTION
Hello,
it seems that in the current filter automation save & load code, there are iterations of 32 iterating over an array of size 16, making it impossible to produce a save on a project using an automation.

It solves the issue on my test case, hopefully I haven't missed anything.

Cheers and thanks a lot for this tool, it's amazing !