### PR TITLE
Draw sharp notes darker than natural notes

### DIFF
--- a/src/gfx.as
+++ b/src/gfx.as
@@ -168,19 +168,27 @@
 				control.barsize = control.boxsize * control.barcount;
 			}
 		}
-		
+
+		public static function lastchar(s:String):String {
+			return (s.length > 0) ? s.charAt(s.length - 1) : "";
+		}
+
 		public static function drawpatterneditor():void {
 			//Pattern editor
 			updateboxsize();
 			
-			//Background alternating colour rows
+			//Draw background colour for each row
+			var isdrumkit:Boolean = control.instrument[control.musicbox[control.currentbox].instr].type >= 1;
 			for (i = 0; i < notesonscreen; i++){
 				var instsize:int = control.pianorollsize;
 				if (control.instrument[control.musicbox[control.currentbox].instr].type >= 1) {
 					instsize = control.drumkit[control.instrument[control.musicbox[control.currentbox].instr].type - 1].size;
 				}
 				if (control.musicbox[control.currentbox].start + i - 1 < instsize) {
-					if (i % 2 == 0) {
+					var n:int = control.musicbox[control.currentbox].start + i - 1;
+					var notename:String = (n > -1) ? control.notename[control.pianoroll[n]] : "";
+					var sharp:Boolean = isdrumkit ? (n % 2 == 0) : (lastchar(notename) == '#');
+					if (!sharp) {
 						fillrect(0, screenheight - linesize - (i * linesize), screenwidth, linesize, 100 + (control.musicbox[control.currentbox].palette * 10));
 						fillrect(0, screenheight - linesize - (i * linesize), screenwidth, 2, 103+(control.musicbox[control.currentbox].palette*10));
 					}else{


### PR DESCRIPTION
Currently, the pattern editor picks the background color of each row in a simple way: if the row's index is even, it draws light blue; otherwise the row is dark blue.

This pull request updates the pattern editor to draw sharp notes in dark blue (C#, D#, F#, G#, A#) and natural notes in light blue (C, D, E, F, G, A, B).

Visually, this makes the pattern editor look similar to a piano: dark keys = sharp notes, light keys = natural notes.

Screenshot:

![image](https://user-images.githubusercontent.com/59632/54927701-ac305400-4ee0-11e9-90f4-d17d6e91904d.png)

(Drumkits retain their old behavior of odd rows = dark blue / even rows = light blue).