### PR TITLE
Add command line export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,6 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+
+# application.xml <content> file
+/BoscaCeoil.swf

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Bosca Ceoil is now stable at version 2.0. However, contibutions are always welco
 
 See [howtobuild.MD](https://github.com/TerryCavanagh/boscaceoil/blob/master/how%20to%20build.MD) for a detailed guide to compiling Bosca Ceoil.
 
+## Command line usage
+
+* If no arguments are supplied, the GUI will open with an empty song.
+* The first positional argument may be a `*.ceol` file to load in the GUI.
+* `--export FILENAME` may be specified to export the loaded song.
+  The filename must end with `.mid`, `.midi`, or `.wav`.
+  The GUI will appear during the export, but will close once complete.
+
+Note that positional arguments must come before named arguments.
+
 ## Open Source Licence
 
 Available under the FreeBSD licence (the same licence which the SiON synth library uses). Feel free to fork Bosca Ceoil and do your own thing with it! FreeBSD licence text follows:

--- a/src/Main.as
+++ b/src/Main.as
@@ -351,6 +351,11 @@ package
 		
 		CONFIG::desktop
 		{
+			public function onCliDone(event:Event):void
+			{
+				NativeApplication.nativeApplication.exit(0);
+			}
+
 			public function onInvokeEvent(event:InvokeEvent):void
 			{
 				if (event.arguments.length > 0)
@@ -369,6 +374,37 @@ package
 					{
 						//Program is up and running, just load now
 						control.invokeceol(event.arguments[0]);
+					}
+
+					if (event.arguments.length > 1)
+					{
+						if (event.arguments[1] == "--export")
+						{
+							NativeApplication.nativeApplication.addEventListener("exportFinished", onCliDone);
+
+							if (event.arguments.length < 3)
+							{
+								NativeApplication.nativeApplication.exit(1);
+							}
+							control.cliExportFile = event.arguments[2];
+
+							if (control.cliExportFile.substr(-4) == ".mid" || control.cliExportFile.substr(-5) == ".midi")
+							{
+								midicontrol.savemidicli(control.cliExportFile);
+							}
+							else if (control.cliExportFile.substr(-4) == ".wav")
+							{
+								control.exportwav();
+							}
+							else
+							{
+								NativeApplication.nativeApplication.exit(1);
+							}
+						}
+						else
+						{
+							NativeApplication.nativeApplication.exit(1);
+						}
 					}
 				}
 			}

--- a/src/control.as
+++ b/src/control.as
@@ -16,6 +16,10 @@
 	import flash.filesystem.*;
 	import flash.net.FileFilter;
 	import flash.system.Capabilities;
+	CONFIG::desktop
+	{
+		import flash.desktop.NativeApplication;
+	}
 	CONFIG::web
 	{
 		import flash.external.ExternalInterface;
@@ -1944,13 +1948,24 @@
 			
 			CONFIG::desktop
 			{
-				if (!filepath)
+				if (cliExportFile)
 				{
-					filepath = defaultDirectory;
+					stream = new FileStream();
+					stream.open(new File(cliExportFile), FileMode.WRITE);
+					stream.writeBytes(_wav, 0, _wav.length);
+					stream.close();
+					NativeApplication.nativeApplication.dispatchEvent(new Event("exportFinished"));
 				}
-				file = filepath.resolvePath("*.wav");
-				file.addEventListener(Event.SELECT, onsavewav);
-				file.browseForSave("Export .wav File");
+				else
+				{
+					if (!filepath)
+					{
+						filepath = defaultDirectory;
+					}
+					file = filepath.resolvePath("*.wav");
+					file.addEventListener(Event.SELECT, onsavewav);
+					file.browseForSave("Export .wav File");
+				}
 			}
 			
 			CONFIG::web
@@ -2096,5 +2111,7 @@
 		public static var savescreencountdown:int;
 		public static var minresizecountdown:int;
 		public static var forceresize:Boolean = false;
+
+		public static var cliExportFile:String = null;
 	}
 }

--- a/src/midicontrol.as
+++ b/src/midicontrol.as
@@ -9,7 +9,11 @@ package {
 	import flash.filesystem.*;
 	import org.si.sion.midi.*;
 	import org.si.sion.events.*;
-	
+	CONFIG::desktop
+	{
+		import flash.desktop.NativeApplication;
+	}
+
 	public class midicontrol {
 		public static var MIDIDRUM_35_Acoustic_Bass_Drum:int = 35;
 		public static var MIDIDRUM_36_Bass_Drum_1:int = 36;
@@ -109,6 +113,21 @@ package {
 			control.savefilesettings();
 		}
 		
+		public static function savemidicli(outputFile:String):void {
+			file = new File(outputFile);
+			convertceoltomidi();
+
+			tempbytes = new ByteArray();
+			tempbytes = clone(midiexporter.midifile.output());
+
+			stream = new FileStream();
+			stream.open(file, FileMode.WRITE);
+			stream.writeBytes(tempbytes, 0, tempbytes.length);
+			stream.close();
+
+			NativeApplication.nativeApplication.dispatchEvent(new Event("exportFinished"));
+		}
+
 		private static function onloadmidi(e:Event):void {  
 			mididata = new ByteArray();
 			file = e.currentTarget as File;


### PR DESCRIPTION
* Documented existing CLI functionality and added MIDI/WAV export via CLI.
* Because of how the WAV export is coupled to the GUI, I ended up using an event callback. For MIDI, I thought it was more straightforward to just make a new method in `midicontrol.as` rather than trying to extricate `onsavemidi()` from `savemidi()`.
* Added `BoscaCeoil.swf` to the ignore file since the build instructions and application.xml point to it being at the root of the repository.